### PR TITLE
Use stable URL for IREE pip-release-links.

### DIFF
--- a/iree-tf/library/setup_tf_importer.sh
+++ b/iree-tf/library/setup_tf_importer.sh
@@ -21,7 +21,7 @@ source "$VENV_DIR/bin/activate" || die "Could not activate venv"
 # Upgrade pip and install requirements. 'python' is used here in order to
 # reference to the python executable from the venv.
 python -m pip install --upgrade pip || die "Could not upgrade pip"
-python -m pip install iree-tools-tf -f https://openxla.github.io/iree/pip-release-links.html
+python -m pip install iree-tools-tf -f https://iree.dev/pip-release-links.html
 python -m pip install tf-nightly
 
 echo "Activate venv with:"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # IREE Python API
 # Use nightly releases instead of PyPi
--f https://openxla.github.io/iree/pip-release-links.html
+-f https://iree.dev/pip-release-links.html
 iree-compiler
 iree-runtime
 iree-tools-tflite


### PR DESCRIPTION
The `openxla.github.io` link depends on a specific GitHub organization, and the IREE repo will be moving soon (multiple times). The `iree.dev` release links URL is recommended here: https://iree.dev/reference/bindings/python/#prebuilt-packages