### PR TITLE
[iree-prof-tools] Start model explorer with the file in the active editor

### DIFF
--- a/iree-prof-tools/model-explorer-extension/README.md
+++ b/iree-prof-tools/model-explorer-extension/README.md
@@ -5,17 +5,16 @@ model explorer within VS Code.
 
 ## How to run it
 
-Model explorer is running as a web server. Once it's installed on a local computer,
-it can be running as a web server and accessed via http://localhost:8080.
+Model explorer must be installed before this extension get started.
 
 ```
 pip install model-explorer
-model-explorer --no_open_in_browser
 ```
 
-Port number can be changed with `--port <port>` option.
-
-Model explorer VS Code extension connects to the web server.
+This extension is started by executing `Model Explorer` command from the Command Palette
+on a VS code active text editor of a graph json file. The extension loads the graph json
+file to the model explorer web server. If the model explorer is not running, it starts one
+with a random port number in a terminal.
 
 ## How to make changes into it
 
@@ -28,7 +27,7 @@ Then, install typescript compiler under the extension directory.
 
 ```
 cd <iree-experimental-root>/iree-prof-tools/model-explorer-extension
-npm install -D typescript
+npm install
 code .
 ```
 

--- a/iree-prof-tools/model-explorer-extension/package.json
+++ b/iree-prof-tools/model-explorer-extension/package.json
@@ -24,6 +24,7 @@
         "watch": "tsc -watch -p ./"
     },
     "devDependencies": {
+        "@types/node": "^20.12.11",
         "@types/vscode": "^1.87.0",
         "typescript": "^5.4.5"
     }

--- a/iree-prof-tools/model-explorer-extension/src/extension.ts
+++ b/iree-prof-tools/model-explorer-extension/src/extension.ts
@@ -1,33 +1,73 @@
 import * as vscode from 'vscode';
 
 export function activate(context: vscode.ExtensionContext) {
-    context.subscriptions.push(
-      vscode.commands.registerCommand('model-explorer.show', () => {
-        const panel = vscode.window.createWebviewPanel(
-          'modelExplorer',
-          'Model Explorer',
-          vscode.ViewColumn.One, // Editor column to show the new webview panel in.
-          { // Webview options.
-            enableScripts: true
-          }
-        );
+  // A random port number of model explorer web server.
+  const port = 30080 + Math.floor(Math.random() * 9900);
 
-        panel.webview.html = getWebviewContent();
+  // Model explorer web server shared by multiple webview panels.
+  var modelExplorerWebServerTerminal: vscode.Terminal|null = null
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('model-explorer.show', () => {
+      const activeTextEditor = vscode.window.activeTextEditor;
+      if (activeTextEditor == null) {
+        console.error("No active text editor.");
+        return
+      }
+
+      // Assume the file of active text editor is of graph json.
+      // TODO(byungchul): Convert MLIR files to graph json on the fly.
+      const modelGraphJson = activeTextEditor.document.fileName;
+
+      const panel = vscode.window.createWebviewPanel(
+        'modelExplorer',
+        'Model Explorer',
+        activeTextEditor.viewColumn ?? vscode.ViewColumn.One,
+        { // Webview options.
+          enableScripts: true
+        }
+      );
+
+      if (modelExplorerWebServerTerminal != null) {
+        panel.webview.html = getWebviewContent(port, modelGraphJson);
+        return;
+      }
+
+      modelExplorerWebServerTerminal =
+        vscode.window.createTerminal(
+          'modelExplorerWebServer',
+          'model-explorer',
+          ['--no_open_in_browser', `--port=${port}`]
+        )
+      vscode.window.onDidCloseTerminal(terminal => {
+        if (terminal == modelExplorerWebServerTerminal) {
+          console.log("Model explorer web server is closed.");
+          modelExplorerWebServerTerminal = null;
+        }
       })
-    );
-  }
+      context.subscriptions.push(modelExplorerWebServerTerminal);
 
-  function getWebviewContent() {
-    return `<!DOCTYPE html>
-  <html lang="en">
-  <head>
-      <meta charset="UTF-8">
-      <title>Model Explorer</title>
-  </head>
-  <body>
-      <iframe src="http://localhost:8080"
-              style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: none;">
-      </iframe>
-  </body>
-  </html>`;
+      const timeout = setTimeout(() => {
+        panel.webview.html = getWebviewContent(port, modelGraphJson);
+      }, 2000); // 2000 is arbitrary. Need a more reliable way.
+
+      panel.onDidDispose(() => { clearTimeout(timeout); }, null, context.subscriptions);
+    })
+  );
+}
+
+function getWebviewContent(port: number, modelGraphJson: string) {
+  const encodedData = encodeURIComponent(`{"models":[{"url":"${modelGraphJson}","adapterId":"builtin_json"}]}`);
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Model Explorer</title>
+</head>
+<body>
+  <iframe src="http://localhost:${port}/?data=${encodedData}&renderer=webgl&show_open_in_new_tab=0"
+          style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: none;">
+  </iframe>
+</body>
+</html>`;
 }


### PR DESCRIPTION
1) Get the filename from the active text editor.
2) Assume it as a graph json file.
3) Start model explorer in a vscode terminal by extension instead of running independently.