### PR TITLE
[iree-prof-tools] Define settings for model explorer extension.

### DIFF
--- a/iree-prof-tools/model-explorer-extension/package.json
+++ b/iree-prof-tools/model-explorer-extension/package.json
@@ -13,10 +13,25 @@
     "contributes": {
         "commands": [
             {
-                "command": "model-explorer.show",
-                "title": "Model Explorer"
+                "command": "modelExplorer.show",
+                "title": "Explore Model"
             }
-        ]
+        ],
+        "configuration": {
+            "title": "Model Explorer",
+            "properties": {
+                "modelExplorer.externalModelExplorerUrl": {
+                    "type": "string",
+                    "description": "URL of model explorer web server to connect. If empty, one will be started internally.",
+                    "default": ""
+                },
+                "modelExplorer.internalModelExplorerPath": {
+                    "type": "string",
+                    "description": "Executable path to start model explorer internally when externalModelExplorerUrl is empty.",
+                    "default": "model-explorer"
+                }
+            }
+        }
     },
     "scripts": {
         "vscode:prepublish": "npm run compile",

--- a/iree-prof-tools/model-explorer-extension/src/extension.ts
+++ b/iree-prof-tools/model-explorer-extension/src/extension.ts
@@ -4,60 +4,73 @@ export function activate(context: vscode.ExtensionContext) {
   // A random port number of model explorer web server.
   const port = 30080 + Math.floor(Math.random() * 9900);
 
-  // Model explorer web server shared by multiple webview panels.
-  var modelExplorerWebServerTerminal: vscode.Terminal|null = null
+  // Internal model explorer web server shared by multiple webview panels.
+  var internalModelExplorerTerminal: vscode.Terminal|null = null
 
-  context.subscriptions.push(
-    vscode.commands.registerCommand('model-explorer.show', () => {
-      const activeTextEditor = vscode.window.activeTextEditor;
-      if (activeTextEditor == null) {
-        console.error("No active text editor.");
-        return
-      }
-
-      // Assume the file of active text editor is of graph json.
-      // TODO(byungchul): Convert MLIR files to graph json on the fly.
-      const modelGraphJson = activeTextEditor.document.fileName;
-
-      const panel = vscode.window.createWebviewPanel(
-        'modelExplorer',
-        'Model Explorer',
-        activeTextEditor.viewColumn ?? vscode.ViewColumn.One,
-        { // Webview options.
-          enableScripts: true
-        }
-      );
-
-      if (modelExplorerWebServerTerminal != null) {
-        panel.webview.html = getWebviewContent(port, modelGraphJson);
+  async function startModelExplorer() {
+    var modelFile = vscode.window.activeTextEditor?.document.fileName;
+    if (!modelFile) {
+      const openFiles = await vscode.window.showOpenDialog({
+        canSelectFiles: true,
+        canSelectMany: false,
+        title: 'No active text editor or too large file. Open a model file'
+      });
+      modelFile = openFiles?.length == 1 ? openFiles[0].fsPath : undefined;
+      if (!modelFile) {
+        vscode.window.showInformationMessage('Invalid model file path.');
         return;
       }
+    }
 
-      modelExplorerWebServerTerminal =
-        vscode.window.createTerminal(
-          'modelExplorerWebServer',
-          'model-explorer',
-          ['--no_open_in_browser', `--port=${port}`]
-        )
-      vscode.window.onDidCloseTerminal(terminal => {
-        if (terminal == modelExplorerWebServerTerminal) {
-          console.log("Model explorer web server is closed.");
-          modelExplorerWebServerTerminal = null;
-        }
-      })
-      context.subscriptions.push(modelExplorerWebServerTerminal);
+    const config = vscode.workspace.getConfiguration('modelExplorer');
+    const externalUrl = config.get<string>('externalModelExplorerUrl') ?? '';
+    const connectToExternalServer = externalUrl.length > 0;
+    const modelExplorerUrl = connectToExternalServer ? externalUrl : `http://localhost:${port}`;
 
-      const timeout = setTimeout(() => {
-        panel.webview.html = getWebviewContent(port, modelGraphJson);
-      }, 2000); // 2000 is arbitrary. Need a more reliable way.
+    const panel = vscode.window.createWebviewPanel(
+      'modelExplorer',
+      'Model Explorer',
+      vscode.window.activeTextEditor?.viewColumn ?? vscode.ViewColumn.One,
+      { // Webview options.
+        enableScripts: true
+      }
+    );
+    if (connectToExternalServer || internalModelExplorerTerminal != null) {
+      panel.webview.html = getWebviewContent(modelExplorerUrl, modelFile);
+      return;
+    }
 
-      panel.onDidDispose(() => { clearTimeout(timeout); }, null, context.subscriptions);
-    })
-  );
+    // No model explorer is available. Starts one.
+    vscode.window.showInformationMessage('Starting a model explorer web server...');
+    internalModelExplorerTerminal =
+      vscode.window.createTerminal(
+        'modelExplorerWebServer',
+        config.get<string>('internalModelExplorerPath') ?? 'model-explorer',
+        ['--no_open_in_browser', `--port=${port}`]
+      );
+    vscode.window.onDidCloseTerminal(terminal => {
+      if (terminal == internalModelExplorerTerminal) {
+        vscode.window.showInformationMessage('Model explorer web server is closed.');
+        internalModelExplorerTerminal = null;
+      }
+    });
+    context.subscriptions.push(internalModelExplorerTerminal);
+
+    // Delay webview rendering to wait for model explorer ready.
+    const timeout = setTimeout(() => {
+      panel.webview.html = getWebviewContent(modelExplorerUrl, modelFile!!);
+    }, 2000); // 2000 is arbitrary. Need a more reliable way.
+
+    panel.onDidDispose(() => { clearTimeout(timeout); }, null, context.subscriptions);
+  }
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('modelExplorer.show', startModelExplorer));
 }
 
-function getWebviewContent(port: number, modelGraphJson: string) {
-  const encodedData = encodeURIComponent(`{"models":[{"url":"${modelGraphJson}","adapterId":"builtin_json"}]}`);
+function getWebviewContent(modelExplorerUrl: string, modelFile: string) {
+  vscode.window.showInformationMessage(`Loading a model file, ${modelFile}...`);
+  const encodedData = encodeURIComponent(`{"models":[{"url":"${modelFile}"}]}`);
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -65,7 +78,7 @@ function getWebviewContent(port: number, modelGraphJson: string) {
   <title>Model Explorer</title>
 </head>
 <body>
-  <iframe src="http://localhost:${port}/?data=${encodedData}&renderer=webgl&show_open_in_new_tab=0"
+  <iframe src="${modelExplorerUrl}/?data=${encodedData}&renderer=webgl&show_open_in_new_tab=0"
           style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: none;">
   </iframe>
 </body>


### PR DESCRIPTION
1) externalModelExplorerUrl is to connect to an external model explorer
   web server running independently to the extension.
2) if externalModelExplorerUrl is empty (by default), start it
   internally by the extension with a command set by
   internalModelExplorerCommand.
3) If activeTextEditor is null, launch open file dialog.
4) Show toast messages instead of console log messages.
5) Now, it doesn't assume the file is a graph json. Can load all types
   of files model-explorer supports including TF, TFLite, and PyTorch.